### PR TITLE
Remove minus character from manifest yaml files

### DIFF
--- a/tests/testcases/helloworld/manifest_full.yml
+++ b/tests/testcases/helloworld/manifest_full.yml
@@ -8,14 +8,14 @@ package:
       location: src/greeting.js
       runtime: nodejs@6
       inputs:
-        - name:
-            type: string
-            description: A person's name
-        - place:
-            type: string
-            description: Where the person is from.
+        name:
+          type: string
+          description: A person's name
+        place:
+          type: string
+          description: Where the person is from.
       outputs:
-        - payload:
-            type: string
-            description: a simple greeting message: Hello, name from place!
+        payload:
+          type: string
+          description: a simple greeting message: Hello, name from place!
 

--- a/tests/testcases/helloworld/manifest_simplified.yml
+++ b/tests/testcases/helloworld/manifest_simplified.yml
@@ -8,8 +8,8 @@ package:
       location: src/greeting.js
       runtime: nodejs
       inputs:
-        - name: string
-        - place: string
+        name: string
+        place: string
       outputs:
-        - payload: string
+        payload: string
 

--- a/tests/testcases/triggerrule/manifest.yml
+++ b/tests/testcases/triggerrule/manifest.yml
@@ -8,10 +8,10 @@ package:
       location: src/greeting.js
       runtime: nodejs
       inputs:
-        - name: string
-        - place: string
+        name: string
+        place: string
       outputs:
-        - payload: string
+        payload: string
   triggers:
     locationUpdate:
       inputs:


### PR DESCRIPTION
This patch is to remove all minus characters from manifest yaml files in test cases.

As we discussed in dev meeting, we will not use arrays. The current parser doesn't not support arrays. So we need to remove minus characters.