### PR TITLE
Add interactive and default flags, WIP integration of defaults and manifest parsing

### DIFF
--- a/cmd/servicedeployer.go
+++ b/cmd/servicedeployer.go
@@ -12,11 +12,13 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
- */
+*/
 
 package cmd
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"github.com/openwhisk/openwhisk-client-go/whisk"
 	"github.com/openwhisk/wskdeploy/utils"
@@ -35,7 +37,7 @@ import (
 //   3. Collect information about the source code files in the working directory
 //   4. Create a deployment plan to create OpenWhisk service
 type ServiceDeployer struct {
-	Actions   map[string]*whisk.Action
+	Actions   map[string]utils.ActionRecord
 	Triggers  map[string]*whisk.Trigger
 	Packages  map[string]*whisk.SentPackageNoPublish
 	Rules     map[string]*whisk.Rule
@@ -44,15 +46,22 @@ type ServiceDeployer struct {
 	Authtoken string
 	Namespace string
 	Apihost   string
+	IsInteractive bool
+	IsDefault bool
+	ManifestPath string
+	ProjectPath string
+	DeploymentPath string
+
 }
 
 // NewServiceDeployer is a Factory to create a new ServiceDeployer
 func NewServiceDeployer() *ServiceDeployer {
 	var dep ServiceDeployer
-	dep.Actions = make(map[string]*whisk.Action)
+	dep.Actions = make(map[string]utils.ActionRecord)
 	dep.Packages = make(map[string]*whisk.SentPackageNoPublish)
 	dep.Triggers = make(map[string]*whisk.Trigger)
 	dep.Rules = make(map[string]*whisk.Rule)
+	dep.IsInteractive = true
 	return &dep
 }
 
@@ -68,11 +77,24 @@ func (deployer *ServiceDeployer) LoadConfiguration(propPath string) error {
 	return nil
 }
 
-// ReadDirectory will collect information from the files on disk. These represent actions
-func (deployer *ServiceDeployer) ReadDirectory(directoryPath string) error {
+// ConstructDeploymentPlan will collect information from the manifest, descriptors, and any
+// defaults to determine what assets need to be installed.
+func (deployer *ServiceDeployer) ConstructDeploymentPlan() error {
 
-	err := filepath.Walk(directoryPath, func(filePath string, f os.FileInfo, err error) error {
-		if filePath != directoryPath {
+	if deployer.IsDefault == true {
+		deployer.ReadDirectory()
+	}
+
+	deployer.HandleYamlDir()
+
+	return nil
+}
+
+// ReadDirectory will collect information from the files on disk. These represent actions
+func (deployer *ServiceDeployer) ReadDirectory() error {
+
+	err := filepath.Walk(deployer.ProjectPath, func(filePath string, f os.FileInfo, err error) error {
+		if filePath != deployer.ProjectPath {
 			isDirectory := utils.IsDirectory(filePath)
 
 			if isDirectory == true {
@@ -82,111 +104,223 @@ func (deployer *ServiceDeployer) ReadDirectory(directoryPath string) error {
 				}
 				err = deployer.CreatePackageFromDirectory(baseName)
 
+				} else {
+					action, err := utils.CreateActionFromFile(deployer.ProjectPath, filePath)
+					utils.Check(err)
+					deployer.Actions[action.Name] = utils.ActionRecord{action, filePath}
+				}
+			}
+			return err
+		})
+
+		utils.Check(err)
+		return nil
+	}
+
+	func (deployer *ServiceDeployer) CreatePackageFromDirectory(directoryName string) error {
+		fmt.Println("Making a package ", directoryName)
+		return nil
+	}
+
+	func (deployer *ServiceDeployer) CreateClient() {
+		baseURL, err := utils.GetURLBase(deployer.Apihost)
+		utils.Check(err)
+		clientConfig := &whisk.Config{
+			AuthToken: deployer.Authtoken,
+			Namespace: deployer.Namespace,
+			BaseURL:   baseURL,
+			Version:   "v1",
+			Insecure:  true, // true if you want to ignore certificate signing
+		}
+		// Setup network client
+		client, err := whisk.NewClient(http.DefaultClient, clientConfig)
+		utils.Check(err)
+		deployer.Client = client
+
+	}
+
+	// DeployActions into OpenWhisk
+	func (deployer *ServiceDeployer) DeployActions() error {
+
+		for _, action := range deployer.Actions {
+			//fmt.Println("Got action ", action.Exec.Code)
+			deployer.createAction(action.Action)
+		}
+		return nil
+	}
+
+	// Utility function to call go-whisk framework to make action
+	func (deployer *ServiceDeployer) createAction(action *whisk.Action) {
+		// call ActionService Thru Client
+		_, _, err := deployer.Client.Actions.Insert(action, false, true)
+		if err != nil {
+			fmt.Println("Got error inserting action ", err)
+		}
+	}
+
+	func (deployer *ServiceDeployer) createPackage(packa *whisk.SentPackageNoPublish) {
+		_, _, err := deployer.Client.Packages.Insert(packa, true)
+		if err != nil {
+			fmt.Errorf("Got error creating package %s.", err)
+		}
+	}
+
+	// Wrapper parser to handle yaml dir
+	func (deployer *ServiceDeployer) HandleYamlDir() error {
+		mm := utils.NewManifestManager()
+		packg, err := mm.ComposePackage(deployer.ManifestPath)
+		utils.Check(err)
+		actions, err := mm.ComposeActions(deployer.ManifestPath)
+		utils.Check(err)
+		if !deployer.SetActions(actions) {
+			log.Panicln("duplication founded during deploy actions")
+		}
+		if !deployer.SetPackage(packg) {
+			log.Panicln("duplication founded during deploy package")
+		}
+
+		deployer.createPackage(packg)
+
+		return nil
+	}
+
+	func printDeploymentAssets(deployer *ServiceDeployer) {
+
+		fmt.Println("----==== OpenWhisk Deployment Plan ====----")
+		fmt.Println("Deploy Packages:")
+		fmt.Println("----------------")
+		for _, pkg := range deployer.Packages {
+			var buffer bytes.Buffer
+			buffer.WriteString(pkg.Namespace)
+			buffer.WriteString("/")
+			buffer.WriteString(pkg.Name)
+			fmt.Printf("    %s (version: %s)\n", buffer.String(), pkg.Version)
+		}
+
+    fmt.Println("\nDeploy Actions:")
+		fmt.Println("----------------")
+		for _, action := range deployer.Actions {
+			var buffer bytes.Buffer
+			buffer.WriteString(action.Action.Namespace)
+			buffer.WriteString("/")
+			buffer.WriteString(action.Action.Name)
+			fmt.Printf("    %s (version: %s)\n", buffer.String(), action.Action.Version)
+		}
+
+
+		fmt.Println("\nDeploy Triggers:")
+		fmt.Println("----------------")
+		for _, trigger := range deployer.Triggers {
+			var buffer bytes.Buffer
+			buffer.WriteString(trigger.Namespace)
+			buffer.WriteString("/")
+			buffer.WriteString(trigger.Name)
+			fmt.Printf("    %s (version: %s)\n", buffer.String(), trigger.Version)
+		}
+
+		fmt.Println("\nDeploy Rules:")
+		fmt.Println("----------------")
+		for _, rule := range deployer.Rules {
+			var buffer bytes.Buffer
+			buffer.WriteString(rule.Namespace)
+			buffer.WriteString("/")
+			buffer.WriteString(rule.Name)
+			fmt.Printf("    %s (version: %s)\n", buffer.String(), rule.Version)
+		}
+
+	}
+
+	// Use relfect util to deploy everything in this service deployer
+	// according some planning?
+	func (deployer *ServiceDeployer) Deploy() error {
+		if (deployer.IsInteractive == true) {
+			printDeploymentAssets(deployer)
+			reader := bufio.NewReader(os.Stdin)
+			fmt.Print("Do you really want to deploy this? (y/n): ")
+
+			text, _ := reader.ReadString('\n')
+			text = strings.TrimSpace(text)
+
+			if strings.EqualFold(text, "y") || strings.EqualFold(text, "yes") {
+					err := deployer.DeployActions()
+					if err != nil {
+						return err
+					}
 			} else {
-				//err = deployer.CreateActionFromFile(filePath)
+				fmt.Println("OK. Cancelling deployment")
 			}
 		}
-		return err
-	})
 
-	utils.Check(err)
-	return nil
-}
-
-func (deployer *ServiceDeployer) CreatePackageFromDirectory(directoryName string) error {
-	fmt.Println("Making a package ", directoryName)
-	return nil
-}
-
-func (deployer *ServiceDeployer) CreateClient() {
-	baseURL, err := utils.GetURLBase(deployer.Apihost)
-	utils.Check(err)
-	clientConfig := &whisk.Config{
-		AuthToken: deployer.Authtoken,
-		Namespace: deployer.Namespace,
-		BaseURL:   baseURL,
-		Version:   "v1",
-		Insecure:  true, // true if you want to ignore certificate signing
-	}
-	// Setup network client
-	client, err := whisk.NewClient(http.DefaultClient, clientConfig)
-	utils.Check(err)
-	deployer.Client = client
-
-}
-
-// DeployActions into OpenWhisk
-func (deployer *ServiceDeployer) DeployActions() error {
-
-	for _, action := range deployer.Actions {
-		//fmt.Println("Got action ", action.Exec.Code)
-		deployer.createAction(action)
-	}
-	return nil
-}
-
-// Utility function to call go-whisk framework to make action
-func (deployer *ServiceDeployer) createAction(action *whisk.Action) {
-	// call ActionService Thru Client
-	_, _, err := deployer.Client.Actions.Insert(action, false, true)
-	if err != nil {
-		fmt.Println("Got error inserting action ", err)
-	}
-}
-
-func (deployer *ServiceDeployer) createPackage(packa *whisk.SentPackageNoPublish) {
-	_, _, err := deployer.Client.Packages.Insert(packa, true)
-	if err != nil {
-		fmt.Errorf("Got error creating package %s.", err)
-	}
-}
-
-// Wrapper parser to handle yaml dir
-func (deployer *ServiceDeployer) HandleYamlDir(manifestpath string) error {
-	mm := utils.NewManifestManager()
-	packg, err := mm.ComposePackage(manifestpath)
-	utils.Check(err)
-	actions, err := mm.ComposeActions(manifestpath)
-	utils.Check(err)
-	if !deployer.SetActions(actions) {
-		log.Panicln("duplication founded during deploy actions")
-	}
-	if !deployer.SetPackage(packg) {
-		log.Panicln("duplication founded during deploy package")
+		return nil
 	}
 
-	deployer.createPackage(packg)
-	deployer.DeployActions()
-	return nil
-}
-
-// Use relfect util to deploy everything in this service deployer
-// according some planning?
-func (deployer *ServiceDeployer) Deploy() {
-}
-
-func (deployer *ServiceDeployer) SetPackage(pkg *whisk.SentPackageNoPublish) bool {
-	deployer.mt.Lock()
-	defer deployer.mt.Unlock()
-	_, exist := deployer.Packages[pkg.Name]
-	if exist {
-		return false
-	}
-	deployer.Packages[pkg.Name] = pkg
-	return true
-}
-
-func (deployer *ServiceDeployer) SetActions(actions []*whisk.Action) bool {
-	deployer.mt.Lock()
-	defer deployer.mt.Unlock()
-
-	for _, action := range actions {
-		fmt.Println(action.Name)
-		_, exist := deployer.Actions[action.Name]
+	func (deployer *ServiceDeployer) SetPackage(pkg *whisk.SentPackageNoPublish) bool {
+		deployer.mt.Lock()
+		defer deployer.mt.Unlock()
+		existPkg, exist := deployer.Packages[pkg.Name]
 		if exist {
-			return false
+			if deployer.IsDefault == true {
+
+				log.Printf("Updating package %s with values from manifest file ", pkg.Name)
+
+				existPkg.Annotations = pkg.Annotations
+				existPkg.Namespace = pkg.Namespace
+				existPkg.Parameters = pkg.Parameters
+				existPkg.Publish = pkg.Publish
+				existPkg.Version = pkg.Version
+
+				deployer.Packages[pkg.Name] = existPkg
+				return true
+			} else {
+				return false
+			}
 		}
-		deployer.Actions[action.Name] = action
+
+		deployer.Packages[pkg.Name] = pkg
+		return true
 	}
-	return true
-}
+
+	func (deployer *ServiceDeployer) SetActions(actions []utils.ActionRecord) bool {
+		deployer.mt.Lock()
+		defer deployer.mt.Unlock()
+
+		for _, action := range actions {
+			fmt.Println(action.Action.Name)
+			existAction, exist := deployer.Actions[action.Action.Name]
+
+			if exist {
+				if deployer.IsDefault == true {
+					// look for actions declared in filesystem default as well as manifest
+					// if one exists, merge if they are the same (either same Filepath or manifest doesn't specify a Filepath)
+					// if they are not the same log error
+					if action.Filepath != "" {
+						if existAction.Filepath != action.Filepath {
+							log.Printf("Action %s has location %s in manifest but already exists at %s", action.Action.Name, action.Filepath, existAction)
+							return false
+						} else {
+							// merge the two, overwrite existing action with manifest values
+							existAction.Action.Annotations = action.Action.Annotations
+							existAction.Action.Exec.Kind = action.Action.Exec.Kind
+							existAction.Action.Limits = action.Action.Limits
+							existAction.Action.Namespace = action.Action.Namespace
+							existAction.Action.Parameters = action.Action.Parameters
+							existAction.Action.Publish = action.Action.Publish
+							existAction.Action.Version = action.Action.Version
+
+							deployer.Actions[action.Action.Name] = existAction
+
+							return true
+						}
+					}
+				} else {
+					// no defaults, so assume everything is in the incoming ActionRecord
+					// return false since it means the action is declared twice in the manifest
+					log.Printf("Action %s is declared more than once", action.Action.Name)
+					return false
+				}
+			}
+			// doesn't exist so just add to deployer actions
+				deployer.Actions[action.Action.Name] = action
+			}
+			return true
+		}

--- a/utils/manifest.go
+++ b/utils/manifest.go
@@ -75,13 +75,15 @@ func readAndParse(mani string) *ManifestYAML {
 	return &maniyaml
 }
 
-func (dm *ManifestManager) ComposeActions(manipath string) ([]*whisk.Action, error) {
+func (dm *ManifestManager) ComposeActions(manipath string) ([]ActionRecord, error) {
 	mani := readAndParse(manipath)
-	var s1 []*whisk.Action = make([]*whisk.Action, 0)
+	var s1 []ActionRecord = make([]ActionRecord, 0)
 	for _, action := range mani.Package.Actions {
 		wskaction, err := CreateActionFromFile(manipath, action.Location)
 		Check(err)
-		s1 = append(s1, wskaction)
+
+		record := ActionRecord{wskaction, action.Location}
+		s1 = append(s1, record)
 	}
 	return s1, nil
 }

--- a/utils/util.go
+++ b/utils/util.go
@@ -32,6 +32,14 @@ import (
 	"strings"
 )
 
+// ActionRecord is a container to keep track of
+// a whisk action struct and a location filepath we use to
+// map files and manifest declared actions
+type ActionRecord struct {
+	Action *whisk.Action
+	Filepath string
+}
+
 // ServerlessBinaryCommand is the CLI name to run serverless
 const ServerlessBinaryCommand = "serverless"
 
@@ -203,4 +211,14 @@ func CreateActionFromFile(manipath, filePath string) (*whisk.Action, error) {
 		return action, nil
 	}
 	return nil, nil
+}
+
+func GetBoolFromString(value string) (bool, error) {
+	if strings.EqualFold(value, "true") || strings.EqualFold(value, "t") || strings.EqualFold(value, "yes") || strings.EqualFold(value, "y") {
+		return true, nil
+	} else if strings.EqualFold(value, "false") || strings.EqualFold(value, "f") || strings.EqualFold(value, "no") || strings.EqualFold(value, "n") {
+		return false, nil
+	}
+
+	return false, fmt.Errorf("Value %s not a valid comparison for boolean", value)
 }


### PR DESCRIPTION
This pull request fixes #31 and #32.  It also begins the integration of defaults and the manifest parsing.

If you try something like `wskdeploy `, it parses the manifest file with any defaults turned OFF and interactive mode turned ON.  In interactive mode, it will print out a primitive report of what will be installed and ask you for confirmation.

If you instead do `wskdeploy --allow-interactive false ` it will not prompt you.  Allowable values for `allow-interactive` and `allow-defaults` is `yes, y, no, n, true, t, false, f`.  These are all case insensitive