### PR TITLE
Add DEPENDENCIES.md to track dependent libraries

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -1,0 +1,9 @@
+# Library dependencies for openwhisk-wskdeploy tool
+
+Like other open source projects, openwhisk-wskdeploy is dependent on open source libraries, we 
+list them here to assure that all code dependencies have Apache 2.0 compatible licenses.
+
+| Library name | Licenses Type | License/Project Link |
+| ------| ------ | ------ |
+| jibber_jabber | Apache 2.0 | https://github.com/cloudfoundry-attic/jibber_jabber |
+| color | MIT | https://github.com/fatih/color |


### PR DESCRIPTION
license type to make sure comply with Apache policy.
Fix issue #73.